### PR TITLE
format definition made safe, fixed issue with converter

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,12 +13,12 @@ var UnFixated  = require('unfixated');
 
 var stream = fs.createReadStream(path.join(__dirname, 'fixedWidth.txt'));
 
-var format = {
-  firstName: 30,
-  lastName:  30,
-  phone:     15,
-  address:  100,
-};
+var format = [
+  [firstName, 30],
+  [lastName,  30],
+  [phone,     15],
+  [address,  100],
+];
 
 // set conversion function
 var iconv = new Iconv('CP1255', 'UTF-8');

--- a/unfixated.js
+++ b/unfixated.js
@@ -47,11 +47,10 @@ function UnFixated(format, opt) {
   this.lineStream = new LineStream();
   
   this.lineStream.on('data', lineToObject);
-  var end = this.end.bind(this);
-  this.end = function() {
-    this.lineStream.end();
-    end();
-  };  
+
+  this.on('finish', function() {
+    self.lineStream.end()
+  })
 }
 
 UnFixated.prototype._transform = function (data, encoding, callback) {
@@ -72,4 +71,3 @@ UnFixated.prototype._transform = function (data, encoding, callback) {
 };
 
 module.exports = UnFixated;
-


### PR DESCRIPTION
Hi I made two changes to your code.

1 fixed issue with converter:

This is how I call your library:

``` javascript
new UnFixated(fc.fixParserConfiguration.structure, {convert: function (buf) {
                return iconv.decode(buf, 'win1252');
            }, rowDelimiter: '\n'});
```

Without the change applied, I experienced decoding problem os win1252-special characers.

2 format definition:
I changed the format-definition from object to array (see readme). Reason: The code seems to rely the assumption, that the order of parameters in objects is defined. However, Javascript does not gurantee that the order is defined, even though in practice it is. Using an array is safe in that respect.
